### PR TITLE
[Upgrade Assistant] Migrate to new page layout

### DIFF
--- a/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana.test.ts
+++ b/x-pack/plugins/upgrade_assistant/__jest__/client_integration/kibana.test.ts
@@ -182,9 +182,7 @@ describe('Kibana deprecations', () => {
       component.update();
 
       expect(exists('kibanaRequestError')).toBe(true);
-      expect(find('kibanaRequestError').text()).toContain(
-        'Could not retrieve Kibana deprecations.'
-      );
+      expect(find('kibanaRequestError').text()).toContain('Could not retrieve Kibana deprecations');
     });
 
     test('handles deprecation service error', async () => {
@@ -217,7 +215,7 @@ describe('Kibana deprecations', () => {
       // Verify top-level callout renders
       expect(exists('kibanaPluginError')).toBe(true);
       expect(find('kibanaPluginError').text()).toContain(
-        'Not all Kibana deprecations were retrieved successfully.'
+        'Not all Kibana deprecations were retrieved successfully'
       );
 
       // Open all deprecations

--- a/x-pack/plugins/upgrade_assistant/public/application/components/coming_soon_prompt.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/coming_soon_prompt.tsx
@@ -16,7 +16,7 @@ export const ComingSoonPrompt: React.FunctionComponent = () => {
   const { ELASTIC_WEBSITE_URL } = docLinks;
 
   return (
-    <EuiPageContent>
+    <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
       <EuiEmptyPrompt
         iconType="wrench"
         data-test-subj="comingSoonPrompt"

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_tab_content.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/deprecation_tab_content.tsx
@@ -9,8 +9,9 @@ import { find, groupBy } from 'lodash';
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 
-import { EuiSpacer, EuiHorizontalRule } from '@elastic/eui';
+import { EuiSpacer, EuiHorizontalRule, EuiPageContent } from '@elastic/eui';
 
+import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
 import { EnrichedDeprecationInfo } from '../../../../common/types';
 import { SectionLoading } from '../../../shared_imports';
 import { GroupByOption, LevelFilterOption, UpgradeAssistantTabProps } from '../types';
@@ -127,7 +128,8 @@ export const DeprecationTabContent: FunctionComponent<CheckupTabProps> = ({
 
   if (deprecations && deprecations.length === 0) {
     return (
-      <div data-test-subj={`${checkupLabel}TabContent`}>
+      <div className={APP_WRAPPER_CLASS} data-test-subj={`${checkupLabel}TabContent`}>
+        <EuiSpacer size="l" />
         <NoDeprecationsPrompt
           deprecationType={checkupLabel}
           navigateToOverviewPage={navigateToOverviewPage}
@@ -139,7 +141,13 @@ export const DeprecationTabContent: FunctionComponent<CheckupTabProps> = ({
   let content: React.ReactNode;
 
   if (isLoading) {
-    content = <SectionLoading>{i18nTexts.isLoading}</SectionLoading>;
+    content = (
+      <div className={APP_WRAPPER_CLASS}>
+        <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
+          <SectionLoading>{i18nTexts.isLoading}</SectionLoading>
+        </EuiPageContent>
+      </div>
+    );
   } else if (deprecations?.length) {
     const levelGroups = groupBy(deprecations, 'level');
     const levelToDeprecationCountMap = Object.keys(levelGroups).reduce((counts, level) => {

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecation_errors.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecation_errors.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
+import { EuiEmptyPrompt, EuiPageContent } from '@elastic/eui';
 
-import { EuiCallOut } from '@elastic/eui';
-
+import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
 import { ResponseError } from '../../lib/api';
 import { getEsDeprecationError } from '../../lib/es_deprecation_errors';
 interface Props {
@@ -17,34 +17,56 @@ interface Props {
 
 export const EsDeprecationErrors: React.FunctionComponent<Props> = ({ error }) => {
   const { code: errorType, message } = getEsDeprecationError(error);
+  let errorPrompt: React.ReactNode;
 
   switch (errorType) {
     case 'unauthorized_error':
-      return (
-        <EuiCallOut
-          title={message}
+      errorPrompt = (
+        <EuiEmptyPrompt
+          title={<h2>{message}</h2>}
           color="danger"
           iconType="alert"
           data-test-subj="permissionsError"
         />
       );
+      break;
     case 'partially_upgraded_error':
-      return (
-        <EuiCallOut
-          title={message}
+      errorPrompt = (
+        <EuiEmptyPrompt
+          title={<h2>{message}</h2>}
           color="warning"
           iconType="alert"
           data-test-subj="partiallyUpgradedWarning"
         />
       );
+      break;
     case 'upgraded_error':
-      return <EuiCallOut title={message} iconType="pin" data-test-subj="upgradedCallout" />;
+      errorPrompt = (
+        <EuiEmptyPrompt
+          title={<h2>{message}</h2>}
+          iconType="pin"
+          data-test-subj="upgradedCallout"
+        />
+      );
+      break;
     case 'request_error':
     default:
-      return (
-        <EuiCallOut title={message} color="danger" iconType="alert" data-test-subj="requestError">
-          {error.message}
-        </EuiCallOut>
+      errorPrompt = (
+        <EuiEmptyPrompt
+          title={<h2>{message}</h2>}
+          body={<p>{error.message}</p>}
+          color="danger"
+          iconType="alert"
+          data-test-subj="requestError"
+        />
       );
   }
+
+  return (
+    <div className={APP_WRAPPER_CLASS}>
+      <EuiPageContent verticalPosition="center" horizontalPosition="center" color="danger">
+        {errorPrompt}
+      </EuiPageContent>
+    </div>
+  );
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/es_deprecations/es_deprecations.tsx
@@ -11,14 +11,12 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiPageBody,
   EuiPageHeader,
   EuiTabbedContent,
   EuiTabbedContentTab,
-  EuiPageContent,
-  EuiPageContentBody,
   EuiToolTip,
   EuiNotificationBadge,
+  EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
@@ -162,51 +160,49 @@ export const EsDeprecationsContent = withRouter(
     }, [api, tabName, isLoading]);
 
     return (
-      <EuiPageBody>
-        <EuiPageContent>
-          <EuiPageHeader
-            pageTitle={i18nTexts.pageTitle}
-            description={i18nTexts.pageDescription}
-            rightSideItems={[
-              <EuiButtonEmpty
-                href={docLinks.links.upgradeAssistant}
-                target="_blank"
-                iconType="help"
-                data-test-subj="documentationLink"
-              >
-                {i18nTexts.docLinkText}
-              </EuiButtonEmpty>,
-            ]}
-          >
-            <EuiToolTip position="bottom" content={i18nTexts.backupDataButton.tooltipText}>
-              <EuiButton
-                fill
-                href={getUrlForApp('management', {
-                  path: 'data/snapshot_restore',
-                })}
-                iconType="popout"
-                iconSide="right"
-                target="_blank"
-              >
-                {i18nTexts.backupDataButton.label}
-              </EuiButton>
-            </EuiToolTip>
-          </EuiPageHeader>
+      <>
+        <EuiPageHeader
+          pageTitle={i18nTexts.pageTitle}
+          description={i18nTexts.pageDescription}
+          rightSideItems={[
+            <EuiButtonEmpty
+              href={docLinks.links.upgradeAssistant}
+              target="_blank"
+              iconType="help"
+              data-test-subj="documentationLink"
+            >
+              {i18nTexts.docLinkText}
+            </EuiButtonEmpty>,
+          ]}
+        >
+          <EuiToolTip position="bottom" content={i18nTexts.backupDataButton.tooltipText}>
+            <EuiButton
+              fill
+              href={getUrlForApp('management', {
+                path: 'data/snapshot_restore',
+              })}
+              iconType="popout"
+              iconSide="right"
+              target="_blank"
+            >
+              {i18nTexts.backupDataButton.label}
+            </EuiButton>
+          </EuiToolTip>
+        </EuiPageHeader>
 
-          <EuiPageContentBody>
-            <EuiTabbedContent
-              data-test-subj={
-                telemetryState === TelemetryState.Running
-                  ? 'upgradeAssistantTelemetryRunning'
-                  : undefined
-              }
-              tabs={tabs}
-              onTabClick={onTabClick}
-              selectedTab={tabs.find((tab) => tab.id === tabName)}
-            />
-          </EuiPageContentBody>
-        </EuiPageContent>
-      </EuiPageBody>
+        <EuiSpacer size="l" />
+
+        <EuiTabbedContent
+          data-test-subj={
+            telemetryState === TelemetryState.Running
+              ? 'upgradeAssistantTelemetryRunning'
+              : undefined
+          }
+          tabs={tabs}
+          onTabClick={onTabClick}
+          selectedTab={tabs.find((tab) => tab.id === tabName)}
+        />
+      </>
     );
   }
 );

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecation_errors.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecation_errors.tsx
@@ -9,8 +9,6 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiPageContent, EuiEmptyPrompt } from '@elastic/eui';
 
-import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
-
 interface Props {
   errorType: 'pluginError' | 'requestError';
 }
@@ -43,37 +41,33 @@ const i18nTexts = {
 export const KibanaDeprecationErrors: React.FunctionComponent<Props> = ({ errorType }) => {
   if (errorType === 'pluginError') {
     return (
-      <div className={APP_WRAPPER_CLASS}>
-        <EuiPageContent
-          verticalPosition="center"
-          horizontalPosition="center"
-          color="danger"
-          data-test-subj="kibanaPluginError"
-        >
-          <EuiEmptyPrompt
-            iconType="alert"
-            title={<h2>{i18nTexts.pluginError.title}</h2>}
-            body={<p>{i18nTexts.pluginError.description}</p>}
-          />
-        </EuiPageContent>
-      </div>
-    );
-  }
-
-  return (
-    <div className={APP_WRAPPER_CLASS}>
       <EuiPageContent
         verticalPosition="center"
         horizontalPosition="center"
         color="danger"
-        data-test-subj="kibanaRequestError"
+        data-test-subj="kibanaPluginError"
       >
         <EuiEmptyPrompt
           iconType="alert"
-          title={<h2>{i18nTexts.loadingError.title}</h2>}
-          body={<p>{i18nTexts.loadingError.description}</p>}
+          title={<h2>{i18nTexts.pluginError.title}</h2>}
+          body={<p>{i18nTexts.pluginError.description}</p>}
         />
       </EuiPageContent>
-    </div>
+    );
+  }
+
+  return (
+    <EuiPageContent
+      verticalPosition="center"
+      horizontalPosition="center"
+      color="danger"
+      data-test-subj="kibanaRequestError"
+    >
+      <EuiEmptyPrompt
+        iconType="alert"
+        title={<h2>{i18nTexts.loadingError.title}</h2>}
+        body={<p>{i18nTexts.loadingError.description}</p>}
+      />
+    </EuiPageContent>
   );
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecation_errors.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecation_errors.tsx
@@ -7,44 +7,73 @@
 
 import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiCallOut } from '@elastic/eui';
+import { EuiPageContent, EuiEmptyPrompt } from '@elastic/eui';
+
+import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
 
 interface Props {
   errorType: 'pluginError' | 'requestError';
 }
 
 const i18nTexts = {
-  pluginError: i18n.translate('xpack.upgradeAssistant.kibanaDeprecationErrors.pluginErrorMessage', {
-    defaultMessage:
-      'Not all Kibana deprecations were retrieved successfully. This list may be incomplete. Check the Kibana server logs for errors.',
-  }),
-  loadingError: i18n.translate(
-    'xpack.upgradeAssistant.kibanaDeprecationErrors.loadingErrorMessage',
-    {
-      defaultMessage:
-        'Could not retrieve Kibana deprecations. Check the Kibana server logs for errors.',
-    }
-  ),
+  pluginError: {
+    title: i18n.translate('xpack.upgradeAssistant.kibanaDeprecationErrors.pluginErrorMessage', {
+      defaultMessage: 'Not all Kibana deprecations were retrieved successfully',
+    }),
+    description: i18n.translate(
+      'xpack.upgradeAssistant.kibanaDeprecationErrors.pluginErrorMessage',
+      {
+        defaultMessage: 'Check the Kibana server logs for errors.',
+      }
+    ),
+  },
+  loadingError: {
+    title: i18n.translate('xpack.upgradeAssistant.kibanaDeprecationErrors.loadingErrorMessage', {
+      defaultMessage: 'Could not retrieve Kibana deprecations',
+    }),
+    description: i18n.translate(
+      'xpack.upgradeAssistant.kibanaDeprecationErrors.loadingErrorMessage',
+      {
+        defaultMessage: 'Check the Kibana server logs for errors.',
+      }
+    ),
+  },
 };
 
 export const KibanaDeprecationErrors: React.FunctionComponent<Props> = ({ errorType }) => {
   if (errorType === 'pluginError') {
     return (
-      <EuiCallOut
-        title={i18nTexts.pluginError}
-        color="warning"
-        iconType="alert"
-        data-test-subj="kibanaPluginError"
-      />
+      <div className={APP_WRAPPER_CLASS}>
+        <EuiPageContent
+          verticalPosition="center"
+          horizontalPosition="center"
+          color="danger"
+          data-test-subj="kibanaPluginError"
+        >
+          <EuiEmptyPrompt
+            iconType="alert"
+            title={<h2>{i18nTexts.pluginError.title}</h2>}
+            body={<p>{i18nTexts.pluginError.description}</p>}
+          />
+        </EuiPageContent>
+      </div>
     );
   }
 
   return (
-    <EuiCallOut
-      title={i18nTexts.loadingError}
-      color="danger"
-      iconType="alert"
-      data-test-subj="kibanaRequestError"
-    />
+    <div className={APP_WRAPPER_CLASS}>
+      <EuiPageContent
+        verticalPosition="center"
+        horizontalPosition="center"
+        color="danger"
+        data-test-subj="kibanaRequestError"
+      >
+        <EuiEmptyPrompt
+          iconType="alert"
+          title={<h2>{i18nTexts.loadingError.title}</h2>}
+          body={<p>{i18nTexts.loadingError.description}</p>}
+        />
+      </EuiPageContent>
+    </div>
   );
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
@@ -12,7 +12,6 @@ import { EuiButtonEmpty, EuiPageContent, EuiPageHeader, EuiSpacer } from '@elast
 import { i18n } from '@kbn/i18n';
 
 import type { DomainDeprecationDetails } from 'kibana/public';
-import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
 import { SectionLoading } from '../../../shared_imports';
 import { useAppContext } from '../../app_context';
 import { NoDeprecationsPrompt } from '../shared';
@@ -142,15 +141,13 @@ export const KibanaDeprecationsContent = withRouter(({ history }: RouteComponent
 
   if (isLoading) {
     content = (
-      <div className={APP_WRAPPER_CLASS}>
-        <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
-          <SectionLoading>{i18nTexts.isLoading}</SectionLoading>
-        </EuiPageContent>
-      </div>
+      <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
+        <SectionLoading>{i18nTexts.isLoading}</SectionLoading>
+      </EuiPageContent>
     );
   } else if (kibanaDeprecations?.length) {
     content = (
-      <>
+      <div data-test-subj="kibanaDeprecationsContent">
         <EuiPageHeader
           bottomBorder
           pageTitle={i18nTexts.pageTitle}
@@ -189,11 +186,11 @@ export const KibanaDeprecationsContent = withRouter(({ history }: RouteComponent
             deprecation={resolveModalContent}
           />
         )}
-      </>
+      </div>
     );
   } else if (error) {
     content = <KibanaDeprecationErrors errorType="requestError" />;
   }
 
-  return <div data-test-subj="kibanaDeprecationsContent">{content}</div>;
+  return <>{content}</>;
 });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations.tsx
@@ -8,17 +8,11 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import {
-  EuiButtonEmpty,
-  EuiPageBody,
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-  EuiSpacer,
-} from '@elastic/eui';
+import { EuiButtonEmpty, EuiPageContent, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import type { DomainDeprecationDetails } from 'kibana/public';
+import { APP_WRAPPER_CLASS } from '../../../../../../../src/core/public';
 import { SectionLoading } from '../../../shared_imports';
 import { useAppContext } from '../../app_context';
 import { NoDeprecationsPrompt } from '../shared';
@@ -135,46 +129,30 @@ export const KibanaDeprecationsContent = withRouter(({ history }: RouteComponent
     getAllDeprecations();
   }, [deprecations, getAllDeprecations]);
 
-  const getPageContent = () => {
-    if (kibanaDeprecations && kibanaDeprecations.length === 0) {
-      return (
-        <NoDeprecationsPrompt
-          deprecationType={i18nTexts.deprecationLabel}
-          navigateToOverviewPage={() => history.push('/overview')}
-        />
-      );
-    }
-
-    let content: React.ReactNode;
-
-    if (isLoading) {
-      content = <SectionLoading>{i18nTexts.isLoading}</SectionLoading>;
-    } else if (kibanaDeprecations?.length) {
-      content = (
-        <KibanaDeprecationList
-          deprecations={kibanaDeprecations}
-          showStepsModal={toggleStepsModal}
-          showResolveModal={toggleResolveModal}
-          reloadDeprecations={getAllDeprecations}
-          isLoading={isLoading}
-        />
-      );
-    } else if (error) {
-      content = <KibanaDeprecationErrors errorType="requestError" />;
-    }
-
+  if (kibanaDeprecations && kibanaDeprecations.length === 0) {
     return (
-      <div data-test-subj="kibanaDeprecationsContent">
-        <EuiSpacer />
-        {content}
+      <NoDeprecationsPrompt
+        deprecationType={i18nTexts.deprecationLabel}
+        navigateToOverviewPage={() => history.push('/overview')}
+      />
+    );
+  }
+
+  let content: React.ReactNode;
+
+  if (isLoading) {
+    content = (
+      <div className={APP_WRAPPER_CLASS}>
+        <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
+          <SectionLoading>{i18nTexts.isLoading}</SectionLoading>
+        </EuiPageContent>
       </div>
     );
-  };
-
-  return (
-    <EuiPageBody>
-      <EuiPageContent>
+  } else if (kibanaDeprecations?.length) {
+    content = (
+      <>
         <EuiPageHeader
+          bottomBorder
           pageTitle={i18nTexts.pageTitle}
           description={i18nTexts.pageDescription}
           rightSideItems={[
@@ -189,23 +167,33 @@ export const KibanaDeprecationsContent = withRouter(({ history }: RouteComponent
           ]}
         />
 
-        <EuiPageContentBody>
-          {getPageContent()}
+        <EuiSpacer size="l" />
 
-          {stepsModalContent && (
-            <StepsModal closeModal={() => toggleStepsModal()} modalContent={stepsModalContent} />
-          )}
+        <KibanaDeprecationList
+          deprecations={kibanaDeprecations}
+          showStepsModal={toggleStepsModal}
+          showResolveModal={toggleResolveModal}
+          reloadDeprecations={getAllDeprecations}
+          isLoading={isLoading}
+        />
 
-          {resolveModalContent && (
-            <ResolveDeprecationModal
-              closeModal={() => toggleResolveModal()}
-              resolveDeprecation={resolveDeprecation}
-              isResolvingDeprecation={isResolvingDeprecation}
-              deprecation={resolveModalContent}
-            />
-          )}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </EuiPageBody>
-  );
+        {stepsModalContent && (
+          <StepsModal closeModal={() => toggleStepsModal()} modalContent={stepsModalContent} />
+        )}
+
+        {resolveModalContent && (
+          <ResolveDeprecationModal
+            closeModal={() => toggleResolveModal()}
+            resolveDeprecation={resolveDeprecation}
+            isResolvingDeprecation={isResolvingDeprecation}
+            deprecation={resolveModalContent}
+          />
+        )}
+      </>
+    );
+  } else if (error) {
+    content = <KibanaDeprecationErrors errorType="requestError" />;
+  }
+
+  return <div data-test-subj="kibanaDeprecationsContent">{content}</div>;
 });

--- a/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/overview/overview.tsx
@@ -8,11 +8,9 @@
 import React, { FunctionComponent, useEffect } from 'react';
 
 import {
-  EuiPageContent,
   EuiPageContentBody,
   EuiText,
   EuiPageHeader,
-  EuiPageBody,
   EuiButtonEmpty,
   EuiFlexItem,
   EuiFlexGroup,
@@ -91,72 +89,68 @@ export const DeprecationsOverview: FunctionComponent<Props> = ({ history }) => {
   }, [breadcrumbs]);
 
   return (
-    <EuiPageBody>
-      <EuiPageContent data-test-subj="overviewPageContent">
-        <EuiPageHeader
-          pageTitle={i18nTexts.pageTitle}
-          rightSideItems={[
-            <EuiButtonEmpty
-              href={docLinks.links.upgradeAssistant}
-              target="_blank"
-              iconType="help"
-              data-test-subj="documentationLink"
-            >
-              {i18nTexts.docLink}
-            </EuiButtonEmpty>,
-          ]}
-        />
+    <div data-test-subj="overviewPageContent">
+      <EuiPageHeader
+        bottomBorder
+        pageTitle={i18nTexts.pageTitle}
+        description={i18nTexts.pageDescription}
+        rightSideItems={[
+          <EuiButtonEmpty
+            href={docLinks.links.upgradeAssistant}
+            target="_blank"
+            iconType="help"
+            data-test-subj="documentationLink"
+          >
+            {i18nTexts.docLink}
+          </EuiButtonEmpty>,
+        ]}
+      />
 
-        <EuiPageContentBody>
-          <>
-            <EuiText data-test-subj="overviewDetail" grow={false}>
-              <p>{i18nTexts.pageDescription}</p>
-            </EuiText>
+      <EuiSpacer size="l" />
 
-            <EuiSpacer />
+      <EuiPageContentBody>
+        <>
+          {/* Remove this in last minor of the current major (e.g., 7.15) */}
+          <LatestMinorBanner />
 
-            {/* Remove this in last minor of the current major (e.g., 7.15) */}
-            <LatestMinorBanner />
+          <EuiSpacer size="xl" />
 
-            <EuiSpacer size="xl" />
+          {/* Deprecation stats */}
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <ESDeprecationStats history={history} />
+            </EuiFlexItem>
 
-            {/* Deprecation stats */}
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <ESDeprecationStats history={history} />
-              </EuiFlexItem>
+            <EuiFlexItem>
+              <KibanaDeprecationStats history={history} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
 
-              <EuiFlexItem>
-                <KibanaDeprecationStats history={history} />
-              </EuiFlexItem>
-            </EuiFlexGroup>
+          <EuiSpacer />
 
-            <EuiSpacer />
+          {/* Deprecation logging */}
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiTitle size="s">
+                <h2>{i18nTexts.deprecationLoggingTitle}</h2>
+              </EuiTitle>
 
-            {/* Deprecation logging */}
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiTitle size="s">
-                  <h2>{i18nTexts.deprecationLoggingTitle}</h2>
-                </EuiTitle>
+              <EuiText>
+                <p>
+                  {i18nTexts.getDeprecationLoggingDescription(
+                    `${nextMajor}.x`,
+                    docLinks.links.elasticsearch.deprecationLogging
+                  )}
+                </p>
+              </EuiText>
 
-                <EuiText>
-                  <p>
-                    {i18nTexts.getDeprecationLoggingDescription(
-                      `${nextMajor}.x`,
-                      docLinks.links.elasticsearch.deprecationLogging
-                    )}
-                  </p>
-                </EuiText>
+              <EuiSpacer size="m" />
 
-                <EuiSpacer size="m" />
-
-                <DeprecationLoggingToggle />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </EuiPageBody>
+              <DeprecationLoggingToggle />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </>
+      </EuiPageContentBody>
+    </div>
   );
 };

--- a/x-pack/plugins/upgrade_assistant/public/application/components/shared/no_deprecations.tsx
+++ b/x-pack/plugins/upgrade_assistant/public/application/components/shared/no_deprecations.tsx
@@ -7,7 +7,7 @@
 
 import React, { FunctionComponent } from 'react';
 
-import { EuiLink, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiLink, EuiEmptyPrompt, EuiPageContent } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -46,18 +46,20 @@ export const NoDeprecationsPrompt: FunctionComponent<Props> = ({
   navigateToOverviewPage,
 }) => {
   return (
-    <EuiEmptyPrompt
-      iconType="faceHappy"
-      data-test-subj="noDeprecationsPrompt"
-      title={<h2>{i18nTexts.emptyPromptTitle}</h2>}
-      body={
-        <>
-          <p data-test-subj="upgradeAssistantIssueSummary">
-            {i18nTexts.getEmptyPromptDescription(deprecationType)}
-          </p>
-          <p>{i18nTexts.getEmptyPromptNextStepsDescription(navigateToOverviewPage)}</p>
-        </>
-      }
-    />
+    <EuiPageContent verticalPosition="center" horizontalPosition="center" color="subdued">
+      <EuiEmptyPrompt
+        iconType="faceHappy"
+        data-test-subj="noDeprecationsPrompt"
+        title={<h2>{i18nTexts.emptyPromptTitle}</h2>}
+        body={
+          <>
+            <p data-test-subj="upgradeAssistantIssueSummary">
+              {i18nTexts.getEmptyPromptDescription(deprecationType)}
+            </p>
+            <p>{i18nTexts.getEmptyPromptNextStepsDescription(navigateToOverviewPage)}</p>
+          </>
+        }
+      />
+    </EuiPageContent>
   );
 };


### PR DESCRIPTION
This PR migrates Upgrade Assistant to use the new page layout.

Related to https://github.com/elastic/kibana/issues/100748

### Screenshots

**Overview page:**
<img width="1478" alt="Screen Shot 2021-06-07 at 12 53 50 PM" src="https://user-images.githubusercontent.com/5226211/121066534-ffc4aa80-c797-11eb-8d88-53231941ba6c.png">
<img width="2063" alt="Screen Shot 2021-06-07 at 1 55 43 PM" src="https://user-images.githubusercontent.com/5226211/121066621-17039800-c798-11eb-9153-23fe8e0a0524.png">

**ES deprecations:**
<img width="1469" alt="Screen Shot 2021-06-07 at 1 01 54 PM" src="https://user-images.githubusercontent.com/5226211/121066420-ddcb2800-c797-11eb-8f0a-5ef9e1cef8b2.png">
<img width="1475" alt="Screen Shot 2021-06-07 at 1 07 18 PM" src="https://user-images.githubusercontent.com/5226211/121066428-df94eb80-c797-11eb-8390-f15832587c50.png">
<img width="1482" alt="Screen Shot 2021-06-07 at 1 16 37 PM" src="https://user-images.githubusercontent.com/5226211/121066432-e02d8200-c797-11eb-854d-bc14cdf52fa2.png">


**Kibana deprecations:**
<img width="1481" alt="Screen Shot 2021-06-07 at 1 00 23 PM" src="https://user-images.githubusercontent.com/5226211/121066262-afe5e380-c797-11eb-9640-afa39089260c.png">
<img width="1479" alt="Screen Shot 2021-06-07 at 1 00 43 PM" src="https://user-images.githubusercontent.com/5226211/121066269-b1171080-c797-11eb-8451-a73ebbfc28dc.png">
<img width="2064" alt="Screen Shot 2021-06-07 at 2 19 14 PM" src="https://user-images.githubusercontent.com/5226211/121070986-613b4800-c79d-11eb-91be-8bceadf86d50.png">
<img width="2071" alt="Screen Shot 2021-06-07 at 2 19 57 PM" src="https://user-images.githubusercontent.com/5226211/121070992-626c7500-c79d-11eb-956a-f155e35f777f.png">
