### PR TITLE
Fix chrome login test

### DIFF
--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -207,7 +207,7 @@ export class SecurityPageObject extends FtrService {
     }
 
     if (expectedResult === 'chrome') {
-      await this.find.byCssSelector('body.euiBody--headerIsFixed', 20000);
+      await this.find.byCssSelector('[data-test-subj="userMenuButton"]', 20000);
       this.log.debug(`Finished login process currentUrl = ${await this.browser.getCurrentUrl()}`);
     }
   }

--- a/x-pack/test/functional/page_objects/security_page.ts
+++ b/x-pack/test/functional/page_objects/security_page.ts
@@ -207,10 +207,7 @@ export class SecurityPageObject extends FtrService {
     }
 
     if (expectedResult === 'chrome') {
-      await this.find.byCssSelector(
-        '[data-test-subj="kibanaChrome"] .kbnAppWrapper:not(.kbnAppWrapper--hiddenChrome)',
-        20000
-      );
+      await this.find.byCssSelector('body.euiBody--headerIsFixed', 20000);
       this.log.debug(`Finished login process currentUrl = ${await this.browser.getCurrentUrl()}`);
     }
   }


### PR DESCRIPTION
The security tests relied on a specific CSS selector to detect when we've left the login page and entered Kibana proper. The changes in `fix/app_container_layout` caused that test to no longer work, so I adjusted the CSS selector to be something that's hopefully more stable