### PR TITLE
[Security Solution] Fix tests for new data screen and update index check

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -25,6 +25,8 @@ import { useShowTimeline } from '../../../common/utils/timeline/use_show_timelin
 import { gutterTimeline } from '../../../common/lib/helpers';
 import { useSourcererScope } from '../../../common/containers/sourcerer';
 import { OverviewEmpty } from '../../../overview/components/overview_empty';
+import { ENDPOINT_METADATA_INDEX } from '../../../../common/constants';
+import { useFetchIndex } from '../../../common/containers/source';
 
 /* eslint-disable react/display-name */
 
@@ -76,13 +78,17 @@ export const SecuritySolutionTemplateWrapper: React.FC<SecuritySolutionPageWrapp
     const { show: isShowingTimelineOverlay } = useDeepEqualSelector((state) =>
       getTimelineShowStatus(state, TimelineId.active)
     );
-
+    const endpointMetadataIndex = useMemo<string[]>(() => {
+      return [ENDPOINT_METADATA_INDEX];
+    }, []);
+    const [, { indexExists: metadataIndexExists }] = useFetchIndex(endpointMetadataIndex, true);
     const { indicesExist } = useSourcererScope();
+    const securityIndicesExist = indicesExist || metadataIndexExists;
 
     /* StyledKibanaPageTemplate is a styled EuiPageTemplate. Security solution currently passes the header and page content as the children of StyledKibanaPageTemplate, as opposed to using the pageHeader prop, which may account for any style discrepancies, such as the bottom border not extending the full width of the page, between EuiPageTemplate and the security solution pages.
      */
 
-    return indicesExist ? (
+    return securityIndicesExist ? (
       <StyledKibanaPageTemplate
         $isTimelineBottomBarVisible={isTimelineBottomBarVisible}
         $isShowingTimelineOverlay={isShowingTimelineOverlay}

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -17,6 +17,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['common', 'endpoint', 'header', 'endpointPageUtils']);
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
+  const browser = getService('browser');
 
   const expectedData = [
     [
@@ -84,10 +85,14 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       it('finds data after load and polling', async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/endpoint/metadata/api_feature', {
+          useCreate: true,
+        });
         await esArchiver.load(
           'x-pack/test/functional/es_archives/endpoint/metadata/destination_index',
           { useCreate: true }
         );
+        await browser.refresh();
         await pageObjects.endpoint.waitForTableToHaveData('endpointListTable', 1100);
         const tableData = await pageObjects.endpointPageUtils.tableData('endpointListTable');
         expect(tableData).to.eql(expectedData);
@@ -96,11 +101,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     describe('when there is data,', () => {
       before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/endpoint/metadata/api_feature', {
+          useCreate: true,
+        });
         await esArchiver.load(
           'x-pack/test/functional/es_archives/endpoint/metadata/destination_index',
           { useCreate: true }
         );
         await pageObjects.endpoint.navigateToEndpointList();
+        await browser.refresh();
       });
       after(async () => {
         await deleteMetadataStream(getService);
@@ -215,11 +224,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     describe('displays the correct table data for the kql queries', () => {
       before(async () => {
+        await esArchiver.load('x-pack/test/functional/es_archives/endpoint/metadata/api_feature', {
+          useCreate: true,
+        });
         await esArchiver.load(
           'x-pack/test/functional/es_archives/endpoint/metadata/destination_index',
           { useCreate: true }
         );
         await pageObjects.endpoint.navigateToEndpointList();
+        await browser.refresh();
       });
       after(async () => {
         await deleteMetadataStream(getService);


### PR DESCRIPTION
## Summary
Updates the index check in the new add data screen in the security solution to include a check for the `metadata` .

In addition, it updates the tests to properly populate data so that the new data screen goes away when it should.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios